### PR TITLE
Update Swagger Core API version to 2.2.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 		<maven-release-plugin.version>2.5.3</maven-release-plugin.version>
 		<nexus-staging-maven-plugin>1.6.8</nexus-staging-maven-plugin>
-		<swagger-api.version>2.2.19</swagger-api.version>
+		<swagger-api.version>2.2.20</swagger-api.version>
 		<swagger-ui.version>5.10.3</swagger-ui.version>
 		<gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
 		<jaxb-impl.version>2.1</jaxb-impl.version>


### PR DESCRIPTION
Why? 
For a long time the Swagger Core library for Jakarta has been **without sources and without javadoc in Maven Central**. This has been very annoying when developing as you cannot lookup documentation from within the IDE, nor can you drill into the source. Arghh!

This has finally [been addressed](https://github.com/swagger-api/swagger-core/pull/4578) and is fixed in `2.2.20` (released 19-DEC-2023). Also this project has been Bug Tickets on this topic ([example](https://github.com/springdoc/springdoc-openapi/issues/2329)) even if the problem is upstream.
 
How to see the issue is fixed?   In Maven Central, compare [2.2.19](https://repo1.maven.org/maven2/io/swagger/core/v3/swagger-core-jakarta/2.2.19/) to [2.2.20](https://repo1.maven.org/maven2/io/swagger/core/v3/swagger-core-jakarta/2.2.20/) and look at the size of 'javadoc' and 'sources' files. 